### PR TITLE
Remove from Page 'required with'

### DIFF
--- a/internal/manchester/request.go
+++ b/internal/manchester/request.go
@@ -4,7 +4,7 @@ import "time"
 
 type tireChangeTimesSearchQuery struct {
 	Amount uint      `form:"amount"`
-	Page   uint      `form:"page" binding:"required_with=Amount"`
+	Page   uint      `form:"page"`
 	From   time.Time `form:"from" time_format:"2006-01-02"`
 }
 


### PR DESCRIPTION
`Page` is required with `amount` means, that 0 is invalid `page` option. 
For example: with `amount` of 10, there is currently no way to fetch only first 10 elements, one could fetch 11-20th, 21-30th and so forth.

When `page` is unset or 0 in query, default `uint` value of 0 could be used, so adding `required_with` introduces bug with `page=0`. 

`Page` number is used to calculate db query `Offset=amount*page`, which must be 0 to get first elements.

On the other hand it seems to be expected behavior, because there is a test for `page=0` and this should return `400`.

```	
t.Run("fail to get subset with invalid offset", func(t *testing.T) {
	reqURL := v2Path + "/tire-change-times?amount=1&page=0"
        ...
}
```
